### PR TITLE
Add Babel transformation to Jest config

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -23,7 +23,9 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/tests/setup.js'],
 
   // Transform
-  transform: {},
+  transform: {
+    '^.+\\.js$': 'babel-jest'
+  },
 
   // Module paths
   moduleDirectories: ['node_modules', 'src'],


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Configure Babel transformation for JavaScript files in Jest

- Enable `babel-jest` transformer for `.js` file extensions


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jest.config.cjs</strong><dd><code>Add Babel transformer for JavaScript files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jest.config.cjs

<ul><li>Added <code>babel-jest</code> transformer configuration for <code>.js</code> files<br> <li> Replaced empty <code>transform</code> object with Babel transformation rule</ul>


</details>


  </td>
  <td><a href="https://github.com/ChunkyNosher/copy-URL-on-hover_ChunkyEdition/pull/99/files#diff-17d090b5ad85e342cd83ee805ef525ea9307d4be9588ac4a7db60042ef6c6d14">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

