### PR TITLE
Add AGENTS.md and tslib dependency for Cursor Cloud development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a Firefox/Chrome browser extension (Manifest V2). No backend services, databases, or external APIs are required.
+
+### Quick reference
+
+| Task | Command |
+|------|---------|
+| Install deps | `npm install` |
+| Lint | `npm run lint` |
+| Format check | `npm run format:check` |
+| Unit + integration tests | `npm test` |
+| Build (production) | `npm run build:prod` |
+| Build (dev) | `npm run build` |
+| E2E tests (Firefox) | `npm run test:extension:firefox` |
+| Full CI pipeline | `npm run ci:full` |
+| Watch mode (dev) | `npm run watch` |
+| Type check | `npm run check:types` |
+
+### Important notes
+
+- **Node.js 22+** is required (see `.nvmrc`).
+- **tslib** must be installed for Playwright E2E tests to work (`playwright-webextext` requires it but doesn't list it as a dependency). It's installed as a production dependency.
+- **Playwright Firefox** must be installed for E2E: `npx playwright install firefox --with-deps`
+- The `vp` command (used in scripts like `npm run lint`, `npm test`) comes from `@voidzero-dev/vite-plus-core` — it is installed via `node_modules/.bin/vp`.
+- `web-ext lint` reports pre-existing warnings/errors (non-square icon, update_url, version format) that are known and not blocking.
+- To run the extension interactively in Firefox, use Playwright's bundled Firefox: `npx web-ext run --source-dir=dist --firefox=$HOME/.cache/ms-playwright/firefox-1497/firefox/firefox`
+- The build output goes to `dist/` (Firefox) and `dist-chrome/` (Chrome).
+- Tests use `jsdom` for unit/integration and real Firefox via Playwright for E2E.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,30 +2,39 @@
 
 ## Cursor Cloud specific instructions
 
-This is a Firefox/Chrome browser extension (Manifest V2). No backend services, databases, or external APIs are required.
+This is a Firefox/Chrome browser extension (Manifest V2). No backend services,
+databases, or external APIs are required.
 
 ### Quick reference
 
-| Task | Command |
-|------|---------|
-| Install deps | `npm install` |
-| Lint | `npm run lint` |
-| Format check | `npm run format:check` |
-| Unit + integration tests | `npm test` |
-| Build (production) | `npm run build:prod` |
-| Build (dev) | `npm run build` |
-| E2E tests (Firefox) | `npm run test:extension:firefox` |
-| Full CI pipeline | `npm run ci:full` |
-| Watch mode (dev) | `npm run watch` |
-| Type check | `npm run check:types` |
+| Task                     | Command                          |
+| ------------------------ | -------------------------------- |
+| Install deps             | `npm install`                    |
+| Lint                     | `npm run lint`                   |
+| Format check             | `npm run format:check`           |
+| Unit + integration tests | `npm test`                       |
+| Build (production)       | `npm run build:prod`             |
+| Build (dev)              | `npm run build`                  |
+| E2E tests (Firefox)      | `npm run test:extension:firefox` |
+| Full CI pipeline         | `npm run ci:full`                |
+| Watch mode (dev)         | `npm run watch`                  |
+| Type check               | `npm run check:types`            |
 
 ### Important notes
 
 - **Node.js 22+** is required (see `.nvmrc`).
-- **tslib** must be installed for Playwright E2E tests to work (`playwright-webextext` requires it but doesn't list it as a dependency). It's installed as a production dependency.
-- **Playwright Firefox** must be installed for E2E: `npx playwright install firefox --with-deps`
-- The `vp` command (used in scripts like `npm run lint`, `npm test`) comes from `@voidzero-dev/vite-plus-core` — it is installed via `node_modules/.bin/vp`.
-- `web-ext lint` reports pre-existing warnings/errors (non-square icon, update_url, version format) that are known and not blocking.
-- To run the extension interactively in Firefox, use Playwright's bundled Firefox: `npx web-ext run --source-dir=dist --firefox=$HOME/.cache/ms-playwright/firefox-1497/firefox/firefox`
+- **tslib** must be installed for Playwright E2E tests to work
+  (`playwright-webextext` requires it but doesn't list it as a dependency). It's
+  installed as a production dependency.
+- **Playwright Firefox** must be installed for E2E:
+  `npx playwright install firefox --with-deps`
+- The `vp` command (used in scripts like `npm run lint`, `npm test`) comes from
+  `@voidzero-dev/vite-plus-core` — it is installed via `node_modules/.bin/vp`.
+- `web-ext lint` reports pre-existing warnings/errors (non-square icon,
+  update_url, version format) that are known and not blocking.
+- To run the extension interactively in Firefox, use Playwright's bundled
+  Firefox:
+  `npx web-ext run --source-dir=dist --firefox=$HOME/.cache/ms-playwright/firefox-1497/firefox/firefox`
 - The build output goes to `dist/` (Firefox) and `dist-chrome/` (Chrome).
-- Tests use `jsdom` for unit/integration and real Firefox via Playwright for E2E.
+- Tests use `jsdom` for unit/integration and real Firefox via Playwright for
+  E2E.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.6.3",
       "dependencies": {
         "eventemitter3": "^5.0.1",
+        "tslib": "^2.8.1",
         "webextension-polyfill": "^0.12.0"
       },
       "devDependencies": {
@@ -18840,6 +18841,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
   },
   "dependencies": {
     "eventemitter3": "^5.0.1",
+    "tslib": "^2.8.1",
     "webextension-polyfill": "^0.12.0"
   },
   "overrides": {


### PR DESCRIPTION
### **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for Cursor Cloud agents by adding `AGENTS.md` and fixing a missing dependency for E2E tests.

### Changes

1. **`AGENTS.md`** — Quick reference table for all common development commands (lint, test, build, watch), documents the `tslib` requirement, notes on running the extension interactively, and known pre-existing `web-ext lint` warnings.

2. **`package.json` / `package-lock.json`** — Added `tslib` as a production dependency. `playwright-webextext` imports it but doesn't declare it, causing all E2E tests to fail with `Cannot find module 'tslib'`.

### Verified Development Environment

| Check | Status |
|-------|--------|
| `npm run lint` | ✅ Pass |
| `npm run format:check` | ✅ Pass |
| `npm test` (1803 tests) | ✅ Pass |
| `npm run build:prod` | ✅ Pass |
| `npm run test:extension:firefox` (74 E2E tests) | ✅ Pass |
| `npm run ci:full` | ✅ Pass |

### Demo

Extension loaded and running in Firefox:

[firefox_extension_demo.mp4](https://cursor.com/agents/bc-c03d41df-bc98-42fd-a8a2-92849b94bf01/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffirefox_extension_demo.mp4)

[Extension loaded in Firefox showing settings](https://cursor.com/agents/bc-c03d41df-bc98-42fd-a8a2-92849b94bf01/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fextension_loaded.webp)
[Extension detecting link hover on Wikipedia](https://cursor.com/agents/bc-c03d41df-bc98-42fd-a8a2-92849b94bf01/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flink_hover_demo.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c03d41df-bc98-42fd-a8a2-92849b94bf01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c03d41df-bc98-42fd-a8a2-92849b94bf01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

### **PR Type**
Documentation


___

### **Description**
- Adds `AGENTS.md` with development environment setup instructions

- Provides quick reference table for common npm commands

- Documents Node.js 22+ requirement and tslib dependency

- Includes notes on running extension interactively with Playwright

- Lists known pre-existing web-ext lint warnings


___



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Development environment setup and command reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AGENTS.md

<ul><li>New file documenting Cursor Cloud development environment setup<br> <li> Quick reference table for all common development commands (install, <br>lint, test, build, watch)<br> <li> Important notes on Node.js 22+ requirement and tslib dependency for <br>Playwright E2E tests<br> <li> Instructions for running extension interactively using Playwright's <br>bundled Firefox<br> <li> Documentation of known pre-existing web-ext lint warnings</ul>


</details>


  </td>
  <td><a href="https://github.com/ChunkyNosher/copy-URL-on-hover_ChunkyEdition/pull/450/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

